### PR TITLE
实现小爱音箱 AirPlay 投屏“隐身模式”，彻底消除《心灵之谜》界面显示

### DIFF
--- a/miair/config.py
+++ b/miair/config.py
@@ -17,7 +17,7 @@ class Speaker:
     name: str = ""
     dlna_name: str = ""
     udn: str = ""
-    use_music_api: bool = true
+    use_music_api: bool = True
     enabled: bool = True
 
     # 不支持无损格式的音箱型号列表

--- a/miair/config.py
+++ b/miair/config.py
@@ -17,7 +17,7 @@ class Speaker:
     name: str = ""
     dlna_name: str = ""
     udn: str = ""
-    use_music_api: bool = False
+    use_music_api: bool = true
     enabled: bool = True
 
     # 不支持无损格式的音箱型号列表

--- a/miair/const.py
+++ b/miair/const.py
@@ -50,7 +50,7 @@ NEED_USE_PLAY_MUSIC_API = [
 ]
 
 # 默认 audio_id (用于 play_by_music_url)
-DEFAULT_AUDIO_ID = "1582971365183456177"
+DEFAULT_AUDIO_ID = " "
 
 # 支持的协议信息 (ConnectionManager GetProtocolInfo) - 仅音频
 SUPPORTED_PROTOCOLS = (


### PR DESCRIPTION
1. miair/config.py
修改内容：
将 Speaker 数据类中的 use_music_api 默认值从 False 更改为 True。

变更对比：
```
 use_music_api: bool = False
====
use_music_api: bool = True
```
目的： 强制程序默认启动音乐 API 伪装逻辑，这是触发“隐身模式”的前提条件。

2. miair/const.py
修改内容：
将 DEFAULT_AUDIO_ID 的值从原有的占位符修改为一个空格字符串 " "。

变更对比：
Python
```
DEFAULT_AUDIO_ID = "1582971365183456177"
====
DEFAULT_AUDIO_ID = " "
```
目的： 利用空格 ID 触发小米音箱 UI 渲染层的静默失效，使音箱在播放时不再跳出任何歌曲界面，从而保持在原生时钟或桌面状态。